### PR TITLE
Replace matplotlib._contour with contourpy for contour calculations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ six==1.16.0
 threadpoolctl==3.5.0                          
 tqdm==4.66.5                             
 zipp==3.20.2                              
-
+contourpy==1.2.1

--- a/src/aquaduct/geom/hdr_contour.py
+++ b/src/aquaduct/geom/hdr_contour.py
@@ -25,16 +25,17 @@ from aquaduct import logger
 
 iscontour = True
 try:
-    from matplotlib import _contour
+    import contourpy
 except ImportError:
-    logger.warning("Cannot import _contour from matplotlib, contour calculations will be skipped.")
+    logger.warning("Cannot import contourpy, contour calculations will be skipped.")
     iscontour = False
 
-
 def hdr2contour(hdr, fraction=0.9):
-    # X,Y,Z,no mask,corner mask,nchunk = 0
-    _c = _contour.QuadContourGenerator(hdr.X, hdr.Y, hdr.Z, None, True, 0)
-    cc = _c.create_contour(hdr.Z.max() * (1 - fraction))
-    if len(cc) == 0:
+    if not iscontour:
         return
-    return hdr.pca.undo(cc[0], pc=[0, 1])
+    level = hdr.Z.max() * (1 - fraction)
+    cg = contourpy.contour_generator(x=hdr.X, y=hdr.Y, z=hdr.Z)
+    contours = cg.lines(level)
+    if len(contours) == 0 or len(contours[0]) == 0:
+        return
+    return hdr.pca.undo(contours[0], pc=[0, 1])


### PR DESCRIPTION
Main changes:

Replaced the use of matplotlib._contour with contourpy for contour calculations.
Why this change:

matplotlib._contour is a private API, not recommended for direct use, and may be unavailable in some environments.
contourpy is a dedicated library for contour calculations, offering better compatibility, a more stable interface, and improved performance.
Impact:

Contour-related features now depend on contourpy instead of matplotlib._contour.
If contourpy is not installed, the relevant features will be skipped with a warning in the log.